### PR TITLE
Send Kafka event as a whole to event callback

### DIFF
--- a/src/main/java/br/com/dojot/kafka/Manager.java
+++ b/src/main/java/br/com/dojot/kafka/Manager.java
@@ -180,7 +180,7 @@ public class Manager {
             if (mCallbacks.containsKey(event)) {
                 List<Function<JSONObject, Integer>> callbackList = mCallbacks.get(event);
                 for (Function<JSONObject, Integer> callback : callbackList) {
-                    callback.apply(dataJson);
+                    callback.apply(kafkaEvent);
                 }
             }
         } catch (JSONException exception) {


### PR DESCRIPTION
Following the same pattern used in iotagent-nodejs:
https://github.com/dojot/iotagent-nodejs/blob/master/lib/index.js#L207

This change is required to support multi-tenant environment