### PR TITLE
Re-throw exceptions that happened during the initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>com.github.dojot</groupId>
             <artifactId>dojot-module-java</artifactId>
-            <version>f1ead0443f81f8c9304a45bfbec39bb55fc60f74</version>
+            <version>6e9cebd903a00e65ac7a9fac00333d769e2fb7a9</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
+++ b/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
@@ -14,10 +14,18 @@ public class IoTAgent {
     private Logger mLogger = Logger.getLogger(IoTAgent.class);
     private Messenger mMessenger;
 
-    public IoTAgent(Long consumerPollTime) {
+    public IoTAgent(Long consumerPollTime) throws Exception {
         this.mMessenger = new Messenger(consumerPollTime);
         mLogger.info("Initializing Messenger for Iotagent-java...");
-        this.mMessenger.init();
+        // The initialization migh fail and exceptions being thrown
+        try {
+            this.mMessenger.init();
+        }
+        // Rethrow
+        catch (Exception ex) {
+            throw ex;
+        }
+
         mLogger.info("... Messenger was successfully initialized.");
         mLogger.info("creating channel...");
         this.mMessenger.createChannel(Config.getInstance().getIotagentDefaultSubject(),"w",false);


### PR DESCRIPTION
The initialization of the messenger might fail, for instance, due to
problems to connect with auth service. If this happens, an exception
will be re-thrown to the upper layers.

Linked to dojot/dojot#1046