### PR TITLE
Feature Flag Device Status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+
+jdk:
+ - openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>1.6.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.6.4</version>
+			<scope>test</scope>
+		</dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
+++ b/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
@@ -1,15 +1,13 @@
 package br.com.dojot.IoTAgent;
 
-import org.json.JSONObject;
-import org.apache.log4j.Logger;
-
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Calendar;
 import java.util.function.BiFunction;
 
-import com.cpqd.app.messenger.Messenger;
+import org.apache.log4j.Logger;
+import org.json.JSONObject;
+
 import com.cpqd.app.config.Config;
+import com.cpqd.app.messenger.Messenger;
 
 
 public class IoTAgent {

--- a/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
+++ b/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
@@ -15,7 +15,7 @@ public class IoTAgent {
     private Messenger mMessenger;
 
     public IoTAgent(Long consumerPollTime) throws Exception {
-        this.mMessenger = new Messenger(consumerPollTime);
+        this.mMessenger = getMessenger(consumerPollTime);
         mLogger.info("Initializing Messenger for Iotagent-java...");
         // The initialization migh fail and exceptions being thrown
         try {
@@ -35,6 +35,10 @@ public class IoTAgent {
             return null;
         });
     }
+
+	public static Messenger getMessenger(Long consumerPollTime) {
+		return new Messenger(consumerPollTime);
+	}
 
     public void generateDeviceCreateEventForActiveDevices(){
         this.mMessenger.generateDeviceCreateEventForActiveDevices();

--- a/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
+++ b/src/main/java/br/com/dojot/IoTAgent/IoTAgent.java
@@ -3,7 +3,9 @@ package br.com.dojot.IoTAgent;
 import org.json.JSONObject;
 import org.apache.log4j.Logger;
 
+import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Calendar;
 import java.util.function.BiFunction;
 
 import com.cpqd.app.messenger.Messenger;
@@ -58,6 +60,24 @@ public class IoTAgent {
         event.put("attrs", attrs);
         this.mMessenger.publish(Config.getInstance().getIotagentDefaultSubject(), tenant, event.toString());
     }
+    
+	/**
+	 * Publish device status, it can be online or offline.
+	 *
+	 * @param deviceId device to be updated
+	 * @param tenant   tenant from which device is to be updated
+	 * @param status   custom status structure
+	 */
+	public void publishStatus(String deviceId, String tenant, JSONObject status) {
+
+		JSONObject metadata = new JSONObject();
+		checkCompleteMetaFields(deviceId, tenant, metadata);
+
+		metadata.put("status", status);
+		this.mMessenger.publish(Config.getInstance().getIotagentDefaultSubject(), tenant,
+				new JSONObject().put("metadata", metadata).toString());
+
+	}
 
     private void checkCompleteMetaFields(String deviceId, String tenant, JSONObject metadata) {
         if (!metadata.has("deviceid")) {

--- a/src/test/java/br/com/dojot/IotAgent/IotAgentTest.java
+++ b/src/test/java/br/com/dojot/IotAgent/IotAgentTest.java
@@ -1,0 +1,131 @@
+package br.com.dojot.IotAgent;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cpqd.app.config.Config;
+import com.cpqd.app.messenger.Messenger;
+
+import br.com.dojot.IoTAgent.IoTAgent;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ IoTAgent.class })
+public class IotAgentTest {
+
+	@Before
+	public void setup() {
+		PowerMockito.mockStatic(IoTAgent.class);
+	}
+
+	@Test
+	public void ShouldPublishMessageWithCustomStatus() throws Exception {
+
+		// given
+
+		String deviceId = "e097bd";
+		String tenant = "admin";
+
+		Messenger messengerMock = mock(Messenger.class);
+		long kafkaDefaultConsumerPollTime = Config.getInstance().getKafkaDefaultConsumerPollTime();
+
+		JSONObject customStatus = new JSONObject();
+		customStatus.put("custom attribute", "sample value");
+		customStatus.put("another custom attribute", "sample value");
+
+		// when
+
+		when(IoTAgent.getMessenger(kafkaDefaultConsumerPollTime)).thenReturn(messengerMock);
+
+		// then
+
+		new IoTAgent(kafkaDefaultConsumerPollTime).publishStatus(deviceId, tenant, customStatus);
+
+		ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> tenantCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+
+		verify(messengerMock, times(1)).publish(subjectCaptor.capture(), tenantCaptor.capture(),
+				messageCaptor.capture());
+
+		assertEquals("subject does not match", "device-data", subjectCaptor.getValue());
+		assertEquals("tenant does not match", tenant, tenantCaptor.getValue());
+		JSONObject message = new JSONObject(messageCaptor.getValue());
+		assertEquals("sample value", message.getJSONObject("metadata").getJSONObject("status").get("custom attribute"));
+		assertEquals("sample value",
+				message.getJSONObject("metadata").getJSONObject("status").get("another custom attribute"));
+
+	}
+
+	@Test
+	public void ShouldPublishWithSubjectPredefined() throws Exception {
+
+		// given
+
+		String deviceId = "e097bd";
+		String tenant = "admin";
+
+		Messenger messengerMock = mock(Messenger.class);
+		long kafkaDefaultConsumerPollTime = Config.getInstance().getKafkaDefaultConsumerPollTime();
+
+		// when
+
+		when(IoTAgent.getMessenger(kafkaDefaultConsumerPollTime)).thenReturn(messengerMock);
+
+		// then
+
+		new IoTAgent(kafkaDefaultConsumerPollTime).publishStatus(deviceId, tenant, null);
+
+		ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> tenantCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+
+		verify(messengerMock, times(1)).publish(subjectCaptor.capture(), tenantCaptor.capture(),
+				messageCaptor.capture());
+
+		assertEquals("subject does not match", "device-data", subjectCaptor.getValue());
+
+	}
+
+	@Test
+	public void ShouldPublishWithInformedTenant() throws Exception {
+
+		// given
+
+		String deviceId = "e097bd";
+		String tenant = "admin";
+
+		Messenger messengerMock = mock(Messenger.class);
+		long kafkaDefaultConsumerPollTime = Config.getInstance().getKafkaDefaultConsumerPollTime();
+
+		// when
+
+		when(IoTAgent.getMessenger(kafkaDefaultConsumerPollTime)).thenReturn(messengerMock);
+
+		// then
+
+		new IoTAgent(kafkaDefaultConsumerPollTime).publishStatus(deviceId, tenant, null);
+
+		ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> tenantCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+
+		verify(messengerMock, times(1)).publish(subjectCaptor.capture(), tenantCaptor.capture(),
+				messageCaptor.capture());
+
+		assertEquals("tenant does not match", "admin", tenantCaptor.getValue());
+
+	}
+
+}


### PR DESCRIPTION
**Overview:**
This PR evolves iotagent-java to be able to flag device status (online or offline). The flag is a kafka message inside device-data topic. Third-part services can look at this messages to discover if the device is online or offline.

The message has the following structure:
```
{
   "metadata":{
      "deviceid":"53b6b1",
      "tenant":"admin",
      "timestamp":1594913180026,
      "status":{
         <custom status structure>
      }
   }
}
```

**Other Informations:**
Zenhub ticket: [1557](https://app.zenhub.com/workspaces/dojot-ws-5ca7620c263982676581b05d/issues/dojot/dojot/1557)